### PR TITLE
Remove Multidex usages

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -59,8 +59,6 @@ android {
         targetSdkVersion androidTargetSdkVersion
         buildToolsVersion '34.0.0'
 
-        multiDexEnabled = true
-
         vectorDrawables.useSupportLibrary = true
         project.ext.set("archivesBaseName", "bchat")
 

--- a/app/buildGradle/dependencies.gradle
+++ b/app/buildGradle/dependencies.gradle
@@ -126,7 +126,6 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-idling-resource:3.5.1'
     androidTestUtil 'androidx.test:orchestrator:1.4.2'
     testImplementation 'org.robolectric:robolectric:4.13'
-    testImplementation 'org.robolectric:shadows-multidex:4.13'
 
     //Lottie Animation
     implementation 'com.airbnb.android:lottie:3.4.0'


### PR DESCRIPTION
### Contributor checklist

- [x] I have tested my contribution on these devices:
 * Google Pixel 9 Pro XL (emulator), Android 15
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

Since the min SDK is 23, it is no longer necessary to use the Multidex library.

See the following for more info: https://developer.android.com/build/multidex#mdex-on-l